### PR TITLE
Removed Token struct

### DIFF
--- a/src/defs.rs
+++ b/src/defs.rs
@@ -44,9 +44,9 @@ pub(crate) const TOKEN_REGEXES: phf::OrderedMap<&str, TokenType> = phf_ordered_m
   r"^/\*[\s\S]*\*/" => TokenType::None, // Multi-line comment
 
   // Literals
-  r"^'([^'])'"      => TokenType::Literal(DataType::Character),
+  r"^'[^']'"        => TokenType::Literal(DataType::Character),
   r"^\d+"           => TokenType::Literal(DataType::Integer),
-  r#"^"([^"]*)""#   => TokenType::Literal(DataType::String),
+  r#"^"[^"]*""#     => TokenType::Literal(DataType::String),
 
   // Datatypes
   r"^char"          => TokenType::DataType,
@@ -101,18 +101,6 @@ pub(crate) const TOKEN_REGEXES: phf::OrderedMap<&str, TokenType> = phf_ordered_m
   // Identifier - Named value representing some value or other entity
   r"^[a-zA-Z_$][a-zA-Z_$0-9]*"  => TokenType::Identifier,
 );
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct Token<'a> {
-  pub(crate) typ: &'a TokenType,
-  pub(crate) value: &'a str,
-}
-
-impl<'a> Token<'a> {
-  pub(crate) fn new(typ: &'a TokenType, value: &'a str) -> Self {
-    Self { typ: typ, value: value }
-  }
-}
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum TokenType {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,13 +5,13 @@ mod utils;
 
 use std::fs;
 use ast::generate_ast;
-use defs::{Program,Token};
+use defs::Program;
 
 use lexer::Parser;
 fn main() {
   let code: String = fs::read_to_string("test.pog").expect("Failed to read the file");
   let mut parser: Parser = Parser::init(code.as_str());
-  let tokens: Vec<Token> = parser.parse();
+  let tokens: Vec<&str> = parser.parse();
 
   let program: Program = generate_ast(&tokens);
   dbg!(&program);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
-use crate::defs::{DataType, DATATYPES};
+use regex::Regex;
+use crate::defs::{DATATYPES,TOKEN_REGEXES,DataType,TokenType};
 
 pub(crate) fn get_datatype_from_str(datatype_str: &str) -> DataType {
   assert_eq!(DATATYPES.len(), 3);
@@ -8,4 +9,13 @@ pub(crate) fn get_datatype_from_str(datatype_str: &str) -> DataType {
     "str"     => DataType::String,
     &_        => panic!("'{}' is not a valid DataType", datatype_str),
   }
+}
+
+pub(crate) fn get_token_type(token: &str) -> &TokenType {
+  for (regex, token_type) in TOKEN_REGEXES.entries() {
+    // Take match from capture group if it is explicitly specified
+    let is_match: bool = Regex::new(regex).unwrap().is_match(token);
+    if is_match { return token_type; }
+  }
+  panic!("Did not get TokenType for '{}'", token);
 }


### PR DESCRIPTION
It did not provide any value to parsing and only increased the complexity unnecessarily. Using only the Tokens value as &str instead.